### PR TITLE
[PR] Fix node 6.x incompatibility when not specifically specifying HMAC key is ascii

### DIFF
--- a/lib/cmcic.js
+++ b/lib/cmcic.js
@@ -10,7 +10,9 @@ var banks = {
 var CMCIC = function () {};
 
 CMCIC.calculateMAC = function (data, key) {
-  return crypto.createHmac('sha1', CMCIC.getHashKey(key)).update(data).digest('hex');
+  var key = CMCIC.getHashKey(key);
+  key = new Buffer(key, 'ascii');
+  return crypto.createHmac('sha1', key).update(data).digest('hex');
 };
 
 CMCIC.getHashKey = function (key) {


### PR DESCRIPTION
Fixes #3